### PR TITLE
Add AI analysis button for coins

### DIFF
--- a/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
+++ b/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
@@ -23,6 +23,7 @@ class CoinDetailScreen extends StatefulWidget {
 class _CoinDetailScreenState extends State<CoinDetailScreen> {
   int riskLevel = 0; // Ensuring it's an integer
   String investmentRecommendation = "No data available";
+  Map<String, dynamic>? aiAnalysis;
 
   @override
   void initState() {
@@ -123,6 +124,14 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
                 color: redColor,
                 () => _showSecurityDialog(),
                 text: "Check Coin Security",
+              ),
+            ),
+            UIHelper.verticalSpaceSm10,
+            Center(
+              child: CustomButton(
+                color: appButtonColor,
+                () => _fetchAndShowAiAnalysis(),
+                text: "AI Analysis",
               ),
             ),
           ],
@@ -255,6 +264,35 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
         );
       },
     );
+  }
+
+  void _fetchAndShowAiAnalysis() async {
+    UserViewModel userViewModel =
+        Provider.of<UserViewModel>(context, listen: false);
+    final result =
+        await userViewModel.fetchCoinAnalysis(coin: widget.coin);
+    if (result != null && result['analysis'] != null) {
+      aiAnalysis = result['analysis'];
+      _showAiDialog();
+    }
+  }
+
+  void _showAiDialog() {
+    showDialog(
+        context: context,
+        builder: (context) {
+          return AlertDialog(
+            title: const Text('AI Analysis'),
+            content: SingleChildScrollView(
+              child: Text(aiAnalysis?['HeadsUp'] ?? 'No analysis available'),
+            ),
+            actions: [
+              TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Close'))
+            ],
+          );
+        });
   }
 
   /// 🔹 Get Risk Level Color

--- a/lib/presentation/screens/dashboard/crypto/model.dart/ai_analysis_model.dart
+++ b/lib/presentation/screens/dashboard/crypto/model.dart/ai_analysis_model.dart
@@ -1,0 +1,14 @@
+import 'dart:convert';
+
+AiAnalysisModel aiAnalysisModelFromJson(String str) => AiAnalysisModel.fromJson(json.decode(str));
+
+class AiAnalysisModel {
+  final Map<String, dynamic> analysis;
+
+  AiAnalysisModel({required this.analysis});
+
+  factory AiAnalysisModel.fromJson(Map<String, dynamic> json) =>
+      AiAnalysisModel(analysis: json['analysis'] ?? {});
+
+  Map<String, dynamic> toJson() => {'analysis': analysis};
+}

--- a/lib/presentation/viewmodels/user_view_model.dart
+++ b/lib/presentation/viewmodels/user_view_model.dart
@@ -688,6 +688,43 @@ Future getAllProductsWithFilters({
     return investmentRanking;
   }
 
+  Future<Map<String, dynamic>?> fetchCoinAnalysis({required CoinModel coin}) async {
+    final url = Uri.parse('https://api.buzdy.com/coinanalysis');
+    Map<String, dynamic> body = {
+      "crypto": {
+        "name": coin.name,
+        "price": coin.rate ?? 0,
+        "performance": {"day": coin.delta?.day ?? 0},
+        "volume": coin.volume ?? 0,
+        "technicals": {"rsi": 55},
+        "btc_correlation": 0.0
+      },
+      "preferences": {"risk_tolerance": "moderate"},
+      "timeframe": "short-term"
+    };
+
+    _logRequest('POST', url.toString(), payload: body);
+
+    final response = await http.post(url,
+        headers: {
+          'Content-Type': 'application/json',
+          'accept': 'application/json'
+        },
+        body: jsonEncode(body));
+
+    _logResponse(url.toString(), jsonDecode(response.body), statusCode: response.statusCode);
+
+    if (response.statusCode == 200) {
+      return jsonDecode(response.body);
+    } else {
+      UIHelper.showMySnak(
+          title: "ERROR",
+          message: "Failed to fetch analysis: ${response.statusCode}",
+          isError: true);
+      return null;
+    }
+  }
+
   void searchCoins(String query) {
     if (query.isEmpty) {
       _filteredCoins = List.from(_coins);


### PR DESCRIPTION
## Summary
- create AiAnalysisModel for coin analysis API
- add method in user_view_model to call coinanalysis endpoint
- update CoinDetailScreen with "AI Analysis" button to fetch and display AI results

## Testing
- `flutter analyze` *(fails: flutter not installed)*
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684680d2e7e0832fa7a1246fb575581d