### PR TITLE
Improve coin details and bubble navigation

### DIFF
--- a/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
+++ b/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
@@ -47,7 +47,13 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
               child: CircleAvatar(
                 radius: 50,
                 backgroundColor: Colors.grey[300],
-                backgroundImage: NetworkImage(widget.coin.imageUri),
+                backgroundImage: NetworkImage(
+                  widget.coin.png64 != null && widget.coin.png64!.isNotEmpty
+                      ? widget.coin.png64!
+                      : widget.coin.webp64 != null && widget.coin.webp64!.isNotEmpty
+                          ? widget.coin.webp64!
+                          : widget.coin.imageUri,
+                ),
               ),
             ),
             UIHelper.verticalSpaceSm20,

--- a/lib/presentation/screens/dashboard/crypto/CryptoBubblesScreen.dart
+++ b/lib/presentation/screens/dashboard/crypto/CryptoBubblesScreen.dart
@@ -10,6 +10,7 @@ import 'package:buzdy/utils/image_loader.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:buzdy/presentation/viewmodels/user_view_model.dart';
+import 'package:buzdy/presentation/screens/dashboard/crypto/CoinDetailScreen.dart';
 
 class CryptoBubblesScreen extends StatefulWidget {
   const CryptoBubblesScreen({Key? key}) : super(key: key);
@@ -206,10 +207,22 @@ class _CryptoBubblesScreenState extends State<CryptoBubblesScreen>
             bubble: bubble,
             selectedTimeframe: _selectedTimeframe,
             imageCache: _imageCache,
+            onViewDetail: () => _openDetail(bubble),
           ),
         );
         break;
       }
+    }
+  }
+
+  void _openDetail(Bubble bubble) async {
+    final userVM = Provider.of<UserViewModel>(context, listen: false);
+    final coin = await userVM.fetchCoinDetail(bubble.model.symbol);
+    if (coin != null && mounted) {
+      Navigator.push(
+        context,
+        MaterialPageRoute(builder: (_) => CoinDetailScreen(coin: coin)),
+      );
     }
   }
 

--- a/lib/presentation/viewmodels/user_view_model.dart
+++ b/lib/presentation/viewmodels/user_view_model.dart
@@ -689,7 +689,7 @@ Future getAllProductsWithFilters({
   }
 
   Future<Map<String, dynamic>?> fetchCoinAnalysis({required CoinModel coin}) async {
-    final url = Uri.parse('https://api.buzdy.com/coinanalysis');
+    final url = Uri.parse('https://api.buzdy.com/coinanalysis?isPremium=true');
     Map<String, dynamic> body = {
       "crypto": {
         "name": coin.name,
@@ -720,6 +720,38 @@ Future getAllProductsWithFilters({
       UIHelper.showMySnak(
           title: "ERROR",
           message: "Failed to fetch analysis: ${response.statusCode}",
+          isError: true);
+      return null;
+    }
+  }
+
+  /// Fetch detailed coin information from LiveCoinWatch
+  Future<CoinModel?> fetchCoinDetail(String symbol) async {
+    final url = Uri.parse('https://api.livecoinwatch.com/coins/single');
+    const apiKey = '6170a07c-9d50-4fc1-89bc-3a9e7030751c';
+    final body = jsonEncode({
+      "currency": "USD",
+      "code": symbol.toUpperCase(),
+      "meta": true
+    });
+
+    _logRequest('POST', url.toString(), payload: body);
+
+    final response = await http.post(url,
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': apiKey
+        },
+        body: body);
+
+    _logResponse(url.toString(), jsonDecode(response.body), statusCode: response.statusCode);
+
+    if (response.statusCode == 200) {
+      return CoinModel.fromJson(jsonDecode(response.body));
+    } else {
+      UIHelper.showMySnak(
+          title: "ERROR",
+          message: "Failed to load coin details: ${response.statusCode}",
           isError: true);
       return null;
     }

--- a/lib/presentation/widgets/bubble_details_dialog.dart
+++ b/lib/presentation/widgets/bubble_details_dialog.dart
@@ -7,12 +7,14 @@ class BubbleDetailsDialog extends StatelessWidget {
   final Bubble bubble;
   final String selectedTimeframe;
   final Map<String, ui.Image> imageCache;
+  final VoidCallback onViewDetail;
 
   const BubbleDetailsDialog({
     Key? key,
     required this.bubble,
     required this.selectedTimeframe,
     required this.imageCache,
+    required this.onViewDetail,
   }) : super(key: key);
 
   String formatPrice(double price) {
@@ -175,23 +177,43 @@ class BubbleDetailsDialog extends StatelessWidget {
             // Actions Section
             Padding(
               padding: const EdgeInsets.all(16.0),
-              child: ElevatedButton(
-                onPressed: () => Navigator.pop(context),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.blueAccent,
-                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                  padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 12),
-                  elevation: 5,
-                  shadowColor: Colors.black45,
-                ),
-                child: const Text(
-                  "Close",
-                  style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  ElevatedButton(
+                    onPressed: () {
+                      Navigator.pop(context);
+                      onViewDetail();
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.green,
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                    ),
+                    child: const Text(
+                      "Detail",
+                      style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold),
+                    ),
                   ),
-                ),
+                  ElevatedButton(
+                    onPressed: () => Navigator.pop(context),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.blueAccent,
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                      elevation: 5,
+                      shadowColor: Colors.black45,
+                    ),
+                    child: const Text(
+                      "Close",
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ],
               ),
             ),
           ],


### PR DESCRIPTION
## Summary
- show coin images reliably in CoinDetailScreen
- open detail page from bubble popups
- fetch single coin info from LiveCoinWatch when opening details
- use premium coin analysis endpoint

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c73f9fb14832f95686ffff9eee8dd