### PR TITLE
Add TradingView chart and improve coin details

### DIFF
--- a/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
+++ b/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
@@ -82,9 +82,15 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
                   shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(15)),
                   child: InAppWebView(
+                    // Build and encode the TradingView symbol
                     initialUrlRequest: URLRequest(
                       url: WebUri(
-                          'https://s.tradingview.com/widgetembed/?symbol=BINANCE:${widget.coin.symbol.toUpperCase()}USDT&interval=D&theme=dark&hidesidetoolbar=1'),
+                        'https://s.tradingview.com/widgetembed/'
+                        '?symbol=${Uri.encodeComponent('BINANCE:${widget.coin.symbol.toUpperCase()}USDT')}'
+                        '&interval=D'
+                        '&theme=dark'
+                        '&hidesidetoolbar=1',
+                      ),
                     ),
                   ),
                 ),

--- a/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
+++ b/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
@@ -59,7 +59,8 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
             // Coin Name & Symbol
             Center(
               child: kText(
-                text: "${widget.coin.name} (${widget.coin.symbol})",
+                text:
+                    "${widget.coin.name} (${widget.coin.code ?? widget.coin.symbol})",
                 fSize: 22.0,
                 fWeight: FontWeight.bold,
                 tColor: mainBlackcolor,
@@ -71,9 +72,9 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
             if (widget.coin.description.trim().isNotEmpty)
               _buildDetailSection("Description", widget.coin.description),
 
-            // TradingView Chart (only if symbol is available)
-            if (widget.coin.symbol.trim().isNotEmpty &&
-                widget.coin.symbol.toUpperCase() != 'N/A')
+            // TradingView Chart (only if a valid code or symbol is available)
+            if ((widget.coin.code ?? widget.coin.symbol).trim().isNotEmpty &&
+                (widget.coin.code ?? widget.coin.symbol).toUpperCase() != 'N/A')
               SizedBox(
                 height: 300,
                 child: Card(

--- a/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
+++ b/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
@@ -80,8 +80,9 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
                     borderRadius: BorderRadius.circular(15)),
                 child: InAppWebView(
                   initialUrlRequest: URLRequest(
-                      url: Uri.parse(
-                          'https://s.tradingview.com/widgetembed/?symbol=${widget.coin.symbol.toUpperCase()}USD&interval=D&theme=dark&hidesidetoolbar=1')),
+                    url: WebUri(
+                        'https://s.tradingview.com/widgetembed/?symbol=${widget.coin.symbol.toUpperCase()}USD&interval=D&theme=dark&hidesidetoolbar=1'),
+                  ),
                 ),
               ),
             ),

--- a/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
+++ b/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
@@ -74,19 +74,6 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
             ),
             UIHelper.verticalSpaceSm10,
 
-            // Description from API when available
-            if (((widget.coin.description.trim().isNotEmpty &&
-                        widget.coin.description != 'No description available') ||
-                    (extraDescription != null && extraDescription!.isNotEmpty)))
-              _buildDetailSection(
-                "Description",
-                widget.coin.description.trim().isNotEmpty &&
-                        widget.coin.description != 'No description available'
-                    ? widget.coin.description
-                    : extraDescription ?? '',
-                maxLines: 3,
-              ),
-
             // TradingView Chart (only if a valid code or symbol is available)
             if ((widget.coin.code ?? widget.coin.symbol).trim().isNotEmpty &&
                 (widget.coin.code ?? widget.coin.symbol).toUpperCase() != 'N/A')
@@ -100,10 +87,12 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
                       shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(15)),
                       child: InAppWebView(
+                        // Build the symbol and encode it for the TradingView URL
                         initialUrlRequest: URLRequest(
                           url: WebUri(
                             'https://s.tradingview.com/widgetembed/'
-                            '?symbol=${_encodedTradingViewSymbol()}'
+                            '?symbol='
+                            '${Uri.encodeComponent('BINANCE:${(widget.coin.code ?? widget.coin.symbol).toUpperCase()}USDT')}'
                             '&interval=D'
                             '&theme=dark'
                             '&hidesidetoolbar=1',
@@ -121,6 +110,19 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
                     ),
                   ],
                 ),
+              ),
+            UIHelper.verticalSpaceSm20,
+
+            // Description from API when available (full text below the chart)
+            if (((widget.coin.description.trim().isNotEmpty &&
+                        widget.coin.description != 'No description available') ||
+                    (extraDescription != null && extraDescription!.isNotEmpty)))
+              _buildDetailSection(
+                "Description",
+                widget.coin.description.trim().isNotEmpty &&
+                        widget.coin.description != 'No description available'
+                    ? widget.coin.description
+                    : extraDescription ?? '',
               ),
             UIHelper.verticalSpaceSm20,
 

--- a/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
+++ b/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
@@ -10,6 +10,7 @@ import 'package:buzdy/presentation/widgets/customText.dart';
 import 'package:buzdy/core/ui_helpers.dart';
 import 'package:buzdy/presentation/widgets/CustomButton.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
 class CoinDetailScreen extends StatefulWidget {
   final CoinModel coin;
@@ -72,8 +73,37 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
             // Description
             _buildDetailSection("Description", widget.coin.description),
 
+            // TradingView Chart
+            SizedBox(
+              height: 300,
+              child: Card(
+                clipBehavior: Clip.antiAlias,
+                elevation: 4,
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(15)),
+                child: InAppWebView(
+                  initialUrlRequest: URLRequest(
+                      url: Uri.parse(
+                          'https://s.tradingview.com/widgetembed/?symbol=${widget.coin.symbol.toUpperCase()}USD&interval=D&theme=dark&hidesidetoolbar=1')),
+                ),
+              ),
+            ),
+            UIHelper.verticalSpaceSm20,
+
+            Center(
+              child: CustomButton(
+                color: appButtonColor,
+                () => _fetchAndShowAiAnalysis(),
+                text: "AI Analysis",
+              ),
+            ),
+            UIHelper.verticalSpaceSm10,
+            _buildAiAnalysisSection(),
+            UIHelper.verticalSpaceSm20,
+
             // Market Cap
-            _buildDetailSection("Market Cap",
+            _buildDetailSection(
+                "Market Cap",
                 "\$${widget.coin.usdMarketCap.toStringAsFixed(2)}"),
 
             // Website
@@ -94,19 +124,6 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
             // Created Timestamp
             _buildDetailSection(
                 "Created", _formatDate(widget.coin.createdTimestamp)),
-
-            UIHelper.verticalSpaceSm20,
-
-            Center(
-              child: CustomButton(
-                color: appButtonColor,
-                () => _fetchAndShowAiAnalysis(),
-                text: "AI Analysis",
-                isLoading: isLoadingAiAnalysis,
-              ),
-            ),
-            UIHelper.verticalSpaceSm10,
-            _buildAiAnalysisSection(),
           ],
         ),
       ),

--- a/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
+++ b/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
@@ -1,6 +1,3 @@
-//////
-///
-library;
 import 'package:buzdy/presentation/screens/dashboard/crypto/model.dart/coinModel.dart';
 import 'package:buzdy/presentation/viewmodels/user_view_model.dart';
 import 'package:buzdy/presentation/widgets/appBar.dart';
@@ -92,8 +89,8 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
 
             Center(
               child: CustomButton(
-                color: appButtonColor,
                 () => _fetchAndShowAiAnalysis(),
+                color: appButtonColor,
                 text: "AI Analysis",
               ),
             ),

--- a/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
+++ b/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
@@ -82,11 +82,11 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
                   shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(15)),
                   child: InAppWebView(
-                    // Build and encode the TradingView symbol
+                    // Build and encode the TradingView symbol using ASCII code
                     initialUrlRequest: URLRequest(
                       url: WebUri(
                         'https://s.tradingview.com/widgetembed/'
-                        '?symbol=${Uri.encodeComponent('BINANCE:${widget.coin.symbol.toUpperCase()}USDT')}'
+                        '?symbol=${_encodedTradingViewSymbol()}'
                         '&interval=D'
                         '&theme=dark'
                         '&hidesidetoolbar=1',
@@ -181,6 +181,14 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
     setState(() {
       isLoadingAiAnalysis = false;
     });
+  }
+
+  String _encodedTradingViewSymbol() {
+    final asciiSymbol = (widget.coin.code != null && widget.coin.code!.trim().isNotEmpty
+            ? widget.coin.code!
+            : widget.coin.symbol)
+        .replaceAll(RegExp(r'[^A-Za-z0-9]'), '');
+    return Uri.encodeComponent('BINANCE:${asciiSymbol.toUpperCase()}USDT');
   }
 
   Widget _buildAiAnalysisSection() {

--- a/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
+++ b/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
@@ -68,7 +68,8 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
             UIHelper.verticalSpaceSm10,
 
             // Description
-            _buildDetailSection("Description", widget.coin.description),
+            if (widget.coin.description.trim().isNotEmpty)
+              _buildDetailSection("Description", widget.coin.description),
 
             // TradingView Chart
             SizedBox(
@@ -81,7 +82,7 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
                 child: InAppWebView(
                   initialUrlRequest: URLRequest(
                     url: WebUri(
-                        'https://s.tradingview.com/widgetembed/?symbol=${widget.coin.symbol.toUpperCase()}USD&interval=D&theme=dark&hidesidetoolbar=1'),
+                        'https://s.tradingview.com/widgetembed/?symbol=BINANCE:${widget.coin.symbol.toUpperCase()}USDT&interval=D&theme=dark&hidesidetoolbar=1'),
                   ),
                 ),
               ),
@@ -93,6 +94,7 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
                 () => _fetchAndShowAiAnalysis(),
                 color: appButtonColor,
                 text: "AI Analysis",
+                isLoading: isLoadingAiAnalysis,
               ),
             ),
             UIHelper.verticalSpaceSm10,
@@ -100,9 +102,10 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
             UIHelper.verticalSpaceSm20,
 
             // Market Cap
-            _buildDetailSection(
-                "Market Cap",
-                "\$${widget.coin.usdMarketCap.toStringAsFixed(2)}"),
+            if (widget.coin.usdMarketCap != 0)
+              _buildDetailSection(
+                  "Market Cap",
+                  "\$${widget.coin.usdMarketCap.toStringAsFixed(2)}"),
 
             // Website
             if (widget.coin.website.isNotEmpty)
@@ -120,8 +123,9 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
                   "Telegram", widget.coin.telegram, Icons.telegram),
 
             // Created Timestamp
-            _buildDetailSection(
-                "Created", _formatDate(widget.coin.createdTimestamp)),
+            if (widget.coin.createdTimestamp != 0)
+              _buildDetailSection(
+                  "Created", _formatDate(widget.coin.createdTimestamp)),
           ],
         ),
       ),
@@ -173,7 +177,7 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
 
   Widget _buildAiAnalysisSection() {
     if (isLoadingAiAnalysis) {
-      return const Center(child: CircularProgressIndicator());
+      return const SizedBox();
     }
     if (aiAnalysis == null) {
       return const SizedBox();

--- a/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
+++ b/lib/presentation/screens/dashboard/crypto/CoinDetailScreen.dart
@@ -71,22 +71,24 @@ class _CoinDetailScreenState extends State<CoinDetailScreen> {
             if (widget.coin.description.trim().isNotEmpty)
               _buildDetailSection("Description", widget.coin.description),
 
-            // TradingView Chart
-            SizedBox(
-              height: 300,
-              child: Card(
-                clipBehavior: Clip.antiAlias,
-                elevation: 4,
-                shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(15)),
-                child: InAppWebView(
-                  initialUrlRequest: URLRequest(
-                    url: WebUri(
-                        'https://s.tradingview.com/widgetembed/?symbol=BINANCE:${widget.coin.symbol.toUpperCase()}USDT&interval=D&theme=dark&hidesidetoolbar=1'),
+            // TradingView Chart (only if symbol is available)
+            if (widget.coin.symbol.trim().isNotEmpty &&
+                widget.coin.symbol.toUpperCase() != 'N/A')
+              SizedBox(
+                height: 300,
+                child: Card(
+                  clipBehavior: Clip.antiAlias,
+                  elevation: 4,
+                  shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(15)),
+                  child: InAppWebView(
+                    initialUrlRequest: URLRequest(
+                      url: WebUri(
+                          'https://s.tradingview.com/widgetembed/?symbol=BINANCE:${widget.coin.symbol.toUpperCase()}USDT&interval=D&theme=dark&hidesidetoolbar=1'),
+                    ),
                   ),
                 ),
               ),
-            ),
             UIHelper.verticalSpaceSm20,
 
             Center(

--- a/lib/presentation/screens/dashboard/crypto/CryptoListScreen.dart
+++ b/lib/presentation/screens/dashboard/crypto/CryptoListScreen.dart
@@ -121,8 +121,14 @@ class _CryptoListView extends StatelessWidget {
                   }
                   final coin = userViewModel.coins[index];
                   return InkWell(
-                    onTap: () {
-                      Get.to(CoinDetailScreen(coin: coin));
+                    onTap: () async {
+                      userViewModel.easyLoadingStart();
+                      final detail =
+                          await userViewModel.fetchCoinDetail(coin.symbol);
+                      userViewModel.easyLoadingStop();
+                      if (detail != null) {
+                        Get.to(CoinDetailScreen(coin: detail));
+                      }
                     },
                     child: Card(
                       margin: const EdgeInsets.symmetric(vertical: 8.0),

--- a/lib/presentation/screens/dashboard/crypto/CryptoListScreen.dart
+++ b/lib/presentation/screens/dashboard/crypto/CryptoListScreen.dart
@@ -123,8 +123,8 @@ class _CryptoListView extends StatelessWidget {
                   return InkWell(
                     onTap: () async {
                       userViewModel.easyLoadingStart();
-                      final detail =
-                          await userViewModel.fetchCoinDetail(coin.symbol);
+                      final detail = await userViewModel
+                          .fetchCoinDetail(coin.code ?? coin.symbol);
                       userViewModel.easyLoadingStop();
                       if (detail != null) {
                         Get.to(CoinDetailScreen(coin: detail));
@@ -190,9 +190,12 @@ class _CryptoListView extends StatelessWidget {
                                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                                     children: [
                                       Text(
-                                        coin.symbol.trim().isNotEmpty
-                                            ? coin.symbol
-                                            : "N/A",
+                                        coin.code != null &&
+                                                coin.code!.trim().isNotEmpty
+                                            ? coin.code!
+                                            : (coin.symbol.trim().isNotEmpty
+                                                ? coin.symbol
+                                                : "N/A"),
                                         style: const TextStyle(
                                           fontSize: 14,
                                           color: Colors.grey,

--- a/lib/presentation/screens/dashboard/crypto/CryptoScreen.dart
+++ b/lib/presentation/screens/dashboard/crypto/CryptoScreen.dart
@@ -184,9 +184,12 @@ class _CryptoListView extends StatelessWidget {
                                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                                     children: [
                                       Text(
-                                        coin.symbol.trim().isNotEmpty
-                                            ? coin.symbol
-                                            : "N/A",
+                                        coin.code != null &&
+                                                coin.code!.trim().isNotEmpty
+                                            ? coin.code!
+                                            : (coin.symbol.trim().isNotEmpty
+                                                ? coin.symbol
+                                                : "N/A"),
                                         style: const TextStyle(
                                           fontSize: 14,
                                           color: Colors.grey,

--- a/lib/presentation/screens/dashboard/crypto/FullScreenChart.dart
+++ b/lib/presentation/screens/dashboard/crypto/FullScreenChart.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+class FullScreenChart extends StatelessWidget {
+  final String url;
+  const FullScreenChart({Key? key, required this.url}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: InAppWebView(initialUrlRequest: URLRequest(url: WebUri(url))),
+    );
+  }
+}

--- a/lib/presentation/screens/dashboard/feed/feed.dart
+++ b/lib/presentation/screens/dashboard/feed/feed.dart
@@ -1,5 +1,6 @@
 import 'package:buzdy/presentation/screens/dashboard/feed/model/youtubeModel.dart';
 import 'package:buzdy/presentation/screens/dashboard/feed/videoplayer.dart';
+import 'package:buzdy/presentation/screens/dashboard/feed/shorts_feed_player.dart';
 import 'package:buzdy/presentation/viewmodels/user_view_model.dart';
 import 'package:buzdy/presentation/widgets/appBar.dart';
 import 'package:flutter/material.dart';
@@ -88,7 +89,15 @@ class _FeedScreenState extends State<FeedScreen> {
                             : SizedBox();
                       }
                       var item = provider.youtubeShorts[index];
-                      return ShortsItem(item: item);
+                      return GestureDetector(
+                        onTap: () {
+                          Get.to(ShortsFeedPlayer(
+                            items: provider.youtubeShorts,
+                            initialIndex: index,
+                          ));
+                        },
+                        child: ShortsItem(item: item),
+                      );
                     },
                   ),
                 ),
@@ -118,7 +127,15 @@ class _FeedScreenState extends State<FeedScreen> {
                           : SizedBox();
                     }
                     var item = provider.youtubeVideos[index];
-                    return VideoItem(item: item);
+                    return GestureDetector(
+                      onTap: () {
+                        Get.to(ShortsFeedPlayer(
+                          items: provider.youtubeVideos,
+                          initialIndex: index,
+                        ));
+                      },
+                      child: VideoItem(item: item),
+                    );
                   },
                 ),
               ],
@@ -138,36 +155,31 @@ class ShortsItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(4.0),
-      child: GestureDetector(
-        onTap: () {
-          Get.to(VideoPlayerScreen(videoId: "QLe58WLMlsg"));
-        },
-        child: Container(
-          margin: EdgeInsets.symmetric(vertical: 5),
-          width: Get.width / 3,
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(15),
-            image: DecorationImage(
-              image: NetworkImage(item.snippet!.thumbnails!.medium!.url!),
-              fit: BoxFit.cover,
-            ),
+      child: Container(
+        margin: EdgeInsets.symmetric(vertical: 5),
+        width: Get.width / 3,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(15),
+          image: DecorationImage(
+            image: NetworkImage(item.snippet!.thumbnails!.medium!.url!),
+            fit: BoxFit.cover,
           ),
-          child: Align(
-            alignment: Alignment.bottomLeft,
-            child: Container(
-              decoration: BoxDecoration(
-                  color: Colors.black.withOpacity(0.5),
-                  borderRadius: BorderRadius.only(
-                      bottomLeft: Radius.circular(15),
-                      bottomRight: Radius.circular(15))),
-              padding: EdgeInsets.all(8),
-              child: Text(
-                item.snippet!.title!,
-                style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 10,
-                    fontWeight: FontWeight.bold),
-              ),
+        ),
+        child: Align(
+          alignment: Alignment.bottomLeft,
+          child: Container(
+            decoration: BoxDecoration(
+                color: Colors.black.withOpacity(0.5),
+                borderRadius: BorderRadius.only(
+                    bottomLeft: Radius.circular(15),
+                    bottomRight: Radius.circular(15))),
+            padding: EdgeInsets.all(8),
+            child: Text(
+              item.snippet!.title!,
+              style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 10,
+                  fontWeight: FontWeight.bold),
             ),
           ),
         ),
@@ -184,64 +196,56 @@ class VideoItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 10),
-      child: GestureDetector(
-        onTap: () {
-          Get.to(VideoPlayerScreen(videoId: "QLe58WLMlsg"));
-        },
-        child: Card(
-          elevation: 2,
-          margin: const EdgeInsets.symmetric(horizontal: 10),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              ClipRRect(
-                borderRadius:
-                    const BorderRadius.vertical(top: Radius.circular(10)),
-                child: Image.network(
-                  item.snippet!.thumbnails!.thumbnailsDefault!.url!,
-                  height: Get.height / 4,
-                  width: double.infinity,
-                  fit: BoxFit.cover,
-                ),
+      child: Card(
+        elevation: 2,
+        margin: const EdgeInsets.symmetric(horizontal: 10),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            ClipRRect(
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(10)),
+              child: Image.network(
+                item.snippet!.thumbnails!.thumbnailsDefault!.url!,
+                height: Get.height / 4,
+                width: double.infinity,
+                fit: BoxFit.cover,
               ),
-              Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    CircleAvatar(
-                      radius: 20,
-                      backgroundColor: Colors.red,
+            ),
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  CircleAvatar(
+                    radius: 20,
+                    backgroundColor: Colors.red,
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const SizedBox(height: 5),
+                        Text(
+                          item.snippet!.title!,
+                          style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+                        ),
+                        const SizedBox(height: 5),
+                        Text(
+                          '${item.snippet!.channelTitle} • ${"3 views"} • ${item.snippet!.publishedAt!.minute} min',
+                          style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+                        ),
+                      ],
                     ),
-                    const SizedBox(width: 10),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          const SizedBox(height: 5),
-                          Text(
-                            item.snippet!.title!,
-                            style: TextStyle(
-                                fontSize: 14, fontWeight: FontWeight.bold),
-                          ),
-                          const SizedBox(height: 5),
-                          Text(
-                            '${item.snippet!.channelTitle} • ${"3 views"} • ${item.snippet!.publishedAt!.minute} min',
-                            style: TextStyle(
-                                fontSize: 12, color: Colors.grey[600]),
-                          ),
-                        ],
-                      ),
-                    ),
-                    const Padding(
-                      padding: EdgeInsets.only(top: 8.0),
-                      child: Icon(Icons.more_vert),
-                    ),
-                  ],
-                ),
+                  ),
+                  const Padding(
+                    padding: EdgeInsets.only(top: 8.0),
+                    child: Icon(Icons.more_vert),
+                  ),
+                ],
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/presentation/screens/dashboard/feed/model/youtubeModel.dart
+++ b/lib/presentation/screens/dashboard/feed/model/youtubeModel.dart
@@ -63,8 +63,12 @@ class Item {
         etag: json["etag"] ?? "",
         id: json["id"] is String
             ? json["id"]
-            : json["id"]?["playlistId"] ?? json["id"]?["videoId"] ?? "",
-        videoId: json["id"] is Map ? json["id"]?["videoId"] : json["id"],
+            : (json["id"] as Map?)?['playlistId'] ??
+                (json["id"] as Map?)?['videoId'] ??
+                "",
+        videoId: json["id"] is Map
+            ? (json["id"] as Map?)?['videoId']
+            : json["id"],
         snippet:
             json["snippet"] != null ? Snippet.fromJson(json["snippet"]) : null,
       );

--- a/lib/presentation/screens/dashboard/feed/model/youtubeModel.dart
+++ b/lib/presentation/screens/dashboard/feed/model/youtubeModel.dart
@@ -47,19 +47,24 @@ class Item {
   final String? kind;
   final String? etag;
   final String? id;
+  final String? videoId;
   final Snippet? snippet;
 
   Item({
     this.kind,
     this.etag,
     this.id,
+    this.videoId,
     this.snippet,
   });
 
   factory Item.fromJson(Map<String, dynamic> json) => Item(
         kind: json["kind"] ?? "",
         etag: json["etag"] ?? "",
-        id: json["id"] ?? "",
+        id: json["id"] is String
+            ? json["id"]
+            : json["id"]?["playlistId"] ?? json["id"]?["videoId"] ?? "",
+        videoId: json["id"] is Map ? json["id"]?["videoId"] : json["id"],
         snippet:
             json["snippet"] != null ? Snippet.fromJson(json["snippet"]) : null,
       );
@@ -68,6 +73,7 @@ class Item {
         "kind": kind,
         "etag": etag,
         "id": id,
+        "videoId": videoId,
         "snippet": snippet?.toJson(),
       };
 }

--- a/lib/presentation/screens/dashboard/feed/model/youtubeModel.dart
+++ b/lib/presentation/screens/dashboard/feed/model/youtubeModel.dart
@@ -58,20 +58,32 @@ class Item {
     this.snippet,
   });
 
-  factory Item.fromJson(Map<String, dynamic> json) => Item(
-        kind: json["kind"] ?? "",
-        etag: json["etag"] ?? "",
-        id: json["id"] is String
-            ? json["id"]
-            : (json["id"] as Map?)?['playlistId'] ??
-                (json["id"] as Map?)?['videoId'] ??
-                "",
-        videoId: json["id"] is Map
-            ? (json["id"] as Map?)?['videoId']
-            : json["id"],
-        snippet:
-            json["snippet"] != null ? Snippet.fromJson(json["snippet"]) : null,
-      );
+  factory Item.fromJson(Map<String, dynamic> json) {
+    final dynamic idField = json['id'];
+
+    String? parsedId;
+    String? parsedVideoId;
+
+    if (idField is Map) {
+      parsedVideoId = idField['videoId'] as String?;
+      parsedId = idField['playlistId'] as String? ?? parsedVideoId ?? '';
+    } else if (idField is String) {
+      parsedId = idField;
+      parsedVideoId = idField;
+    } else {
+      parsedId = '';
+      parsedVideoId = '';
+    }
+
+    return Item(
+      kind: json['kind'] ?? '',
+      etag: json['etag'] ?? '',
+      id: parsedId,
+      videoId: parsedVideoId,
+      snippet:
+          json['snippet'] != null ? Snippet.fromJson(json['snippet']) : null,
+    );
+  }
 
   Map<String, dynamic> toJson() => {
         "kind": kind,

--- a/lib/presentation/screens/dashboard/feed/shorts_feed_player.dart
+++ b/lib/presentation/screens/dashboard/feed/shorts_feed_player.dart
@@ -21,7 +21,7 @@ class _ShortsFeedPlayerState extends State<ShortsFeedPlayer> {
     _pageController = PageController(initialPage: widget.initialIndex);
     _controllers = widget.items
         .map((item) => YoutubePlayerController(
-              initialVideoId: item.id ?? '',
+              initialVideoId: item.videoId ?? '',
               flags: const YoutubePlayerFlags(autoPlay: false, mute: false),
             ))
         .toList();

--- a/lib/presentation/viewmodels/user_view_model.dart
+++ b/lib/presentation/viewmodels/user_view_model.dart
@@ -791,7 +791,7 @@ Future getAllProductsWithFilters({
     }
 
     var url = Uri.parse(
-        'https://www.googleapis.com/youtube/v3/playlists?part=snippet&channelId=UCZNZj3mkdCGJfCoKyl4bSYQ&maxResults=5&pageToken=${nextPageTokenShorts ?? ''}&key=AIzaSyATK5cfxRwEFXlp73Su6HrExL5_6Z0puYw');
+        'https://www.googleapis.com/youtube/v3/search?part=snippet&type=video&channelId=UCZNZj3mkdCGJfCoKyl4bSYQ&maxResults=5&pageToken=${nextPageTokenShorts ?? ''}&key=AIzaSyATK5cfxRwEFXlp73Su6HrExL5_6Z0puYw');
 
     _logRequest('GET', url.toString());
 
@@ -827,7 +827,7 @@ Future getAllProductsWithFilters({
     }
 
     var url = Uri.parse(
-        'https://www.googleapis.com/youtube/v3/playlists?part=snippet&channelId=UCqK_GSMbpiV8spgD3ZGloSw&maxResults=10&pageToken=${nextPageTokenVideos ?? ''}&key=AIzaSyATK5cfxRwEFXlp73Su6HrExL5_6Z0puYw');
+        'https://www.googleapis.com/youtube/v3/search?part=snippet&type=video&channelId=UCqK_GSMbpiV8spgD3ZGloSw&maxResults=10&pageToken=${nextPageTokenVideos ?? ''}&key=AIzaSyATK5cfxRwEFXlp73Su6HrExL5_6Z0puYw');
 
     _logRequest('GET', url.toString());
 

--- a/lib/presentation/widgets/bubble_details_dialog.dart
+++ b/lib/presentation/widgets/bubble_details_dialog.dart
@@ -177,43 +177,23 @@ class BubbleDetailsDialog extends StatelessWidget {
             // Actions Section
             Padding(
               padding: const EdgeInsets.all(16.0),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                children: [
-                  ElevatedButton(
-                    onPressed: () {
-                      Navigator.pop(context);
-                      onViewDetail();
-                    },
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.green,
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-                    ),
-                    child: const Text(
-                      "Detail",
-                      style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold),
-                    ),
+              child: ElevatedButton(
+                onPressed: () => Navigator.pop(context),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.blueAccent,
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                  padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 12),
+                  elevation: 5,
+                  shadowColor: Colors.black45,
+                ),
+                child: const Text(
+                  "Close",
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
                   ),
-                  ElevatedButton(
-                    onPressed: () => Navigator.pop(context),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.blueAccent,
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-                      elevation: 5,
-                      shadowColor: Colors.black45,
-                    ),
-                    child: const Text(
-                      "Close",
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 16,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ),
-                ],
+                ),
               ),
             ),
           ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
   flutter_easyloading: ^3.0.5
   lottie: ^3.3.1
   youtube_player_flutter: ^9.1.1
+  flutter_inappwebview: ^6.1.5
   image_picker: ^1.1.2
   dio: ^5.8.0+1
   http_parser:


### PR DESCRIPTION
## Summary
- fetch detailed coin data before opening details
- show TradingView chart in the detail page
- keep single loader while AI analysis loads
- add `flutter_inappwebview` dependency for web view support

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c778edb18832f81c20efc8707992a