### PR TITLE
Add LocalVideos screen route

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:buzdy/presentation/screens/splash/splash.dart';
+import 'package:buzdy/presentation/screens/dashboard/feed/local_videos_screen.dart';
 import 'package:buzdy/presentation/viewmodels/user_view_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
@@ -47,6 +48,9 @@ class MyApp extends StatelessWidget {
         darkTheme: darkTheme,
         themeMode: ThemeMode.system,
         home: SplashScreen(),
+        routes: {
+          '/localVideos': (_) => const LocalVideosScreen(),
+        },
         builder: EasyLoading.init(),
       ),
     );

--- a/lib/presentation/screens/dashboard/feed/feed.dart
+++ b/lib/presentation/screens/dashboard/feed/feed.dart
@@ -63,11 +63,7 @@ class _FeedScreenState extends State<FeedScreen> {
           actionwidget: IconButton(
             icon: const Icon(Icons.video_library),
             onPressed: () {
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (_) => const LocalVideosScreen(),
-                ),
-              );
+              Navigator.of(context).pushNamed('/localVideos');
             },
           )),
       body: Consumer<UserViewModel>(


### PR DESCRIPTION
## Summary
- open LocalVideosScreen from Feed via named route
- register LocalVideosScreen route in main.dart

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530379eb7c832f9c2e5315434a05c2